### PR TITLE
test: add a local testing strategy

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ jobs:
   test-repo-integration-local:
     docker:
       - image: cimg/node:16.14
+    resource_class: xlarge
     steps:
       - checkout
       - install-python
@@ -29,6 +30,7 @@ jobs:
   test-repo-integration-gitsubtree:
     docker:
       - image: cimg/node:16.14
+    resource_class: xlarge
     environment:
       - GIT_AUTHOR_NAME: "Tester"
       - GIT_AUTHOR_EMAIL: tester@determined.ai

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,15 @@ commands:
 
 # Define the jobs
 jobs:
-  test-repo-integration:
+  test-repo-integration-local:
+    docker:
+      - image: cimg/node:16.14
+    steps:
+      - checkout
+      - install-python
+      - run: ./bin/test.py --repos core --test-local
+
+  test-repo-integration-gitsubtree:
     docker:
       - image: cimg/node:16.14
     environment:
@@ -35,4 +43,5 @@ jobs:
 workflows:
   test:
     jobs:
-      - test-repo-integration
+      - test-repo-integration-local
+      - test-repo-integration-gitsubtree

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,6 @@ jobs:
   test-repo-integration-local:
     docker:
       - image: cimg/node:16.14
-    resource_class: xlarge
     steps:
       - checkout
       - install-python
@@ -30,7 +29,6 @@ jobs:
   test-repo-integration-gitsubtree:
     docker:
       - image: cimg/node:16.14
-    resource_class: xlarge
     environment:
       - GIT_AUTHOR_NAME: "Tester"
       - GIT_AUTHOR_EMAIL: tester@determined.ai

--- a/bin/test.py
+++ b/bin/test.py
@@ -157,6 +157,14 @@ def get_user_inputs():
         if args.sw_hash:
             raise argparse.ArgumentError(None,
                                      '--sw-hash cannot be used with --test-local')
+        # best effort check to make sure we're running in the right directory
+        # check these files and directories exist in the current directory
+        to_check = ['types.ts', 'bin', 'Makefile', 'components', 'configs']
+        for f in to_check:
+            if not pathlib.Path(f).exists():
+                raise argparse.ArgumentError(None, 'it looks like this is not running from ' +
+                                             f'shared-web root: {f} does not exist')
+
 
     return args, repos_to_test, sw_hash
 

--- a/bin/test.py
+++ b/bin/test.py
@@ -30,7 +30,10 @@ def print_colored(skk): print("\033[93m {}\033[00m" .format(skk))
 
 
 def run(command, cwd: t.Optional[pathlib.Path] = None):
-    print_colored(f'{command} [cwd: {cwd}]')
+    msg = command
+    if cwd is not None:
+        msg = f'{command} [cwd: {cwd}]'
+    print_colored(msg)
     subprocess.run(command, cwd=cwd, check=True, shell=True)
 
 
@@ -63,6 +66,7 @@ def setup_user(user, name: str, sm_hash: t.Optional[str] = None, repo_hash: t.Op
     web_dir = clone_dir / user['web_dir']
     run(f'rm -rf {clone_dir}; git clone {user["repo"]} {clone_dir} --recurse-submodules')
     run(f'git checkout {repo_hash}', cwd=clone_dir)
+    run('make get-deps', cwd=web_dir) # calls submodule update
 
     if sm_hash is None: return clone_dir
     # update the shared code
@@ -80,7 +84,7 @@ def run_webui_tests(web_dir: pathlib.Path):
     """
     runs webui tests. requires web_dir to be set up
     """
-    for target in ['get-deps', 'check', 'build', 'test']:
+    for target in ['check', 'build', 'test']:
         run(f'make {target}', cwd=web_dir)
 
 
@@ -91,23 +95,21 @@ def overwrite_with_cur_shared(user, name: str):
     """
     clone_dir = '/tmp' / pathlib.Path(name)
     web_dir = clone_dir / user['web_dir']
-    run(f'rm -rf {clone_dir}; git clone {user["repo"]} {clone_dir} --recurse-submodules')
     dest = web_dir / SHARED_DIR
-    src = pathlib.Path.cwd() # FIXME find out where the current shared dir is relative to the test script
-    run(f'rm -rf {dest}; mkdir -p {dest}')
-    run(f'cp -r {src} {dest}')
+    run(f'rm -rf {dest}')
+    run(f'cp -r . {dest}') # copy the current dir (SHARED_DIR) to dest
 
 
-def test(sm_hash: str, repo_names: t.List[str]):
+def test(sm_hash: str, repo_names: t.List[str], args):
     for name in repo_names:
         if name not in repos:
             raise ValueError(f'unknown repo name: {name}')
         user = repos[name]
-        clone_dir = setup_user(user, name, sm_hash)
+        clone_dir = setup_user(user, name, sm_hash, repo_hash=args.repo_hash)
         web_dir = clone_dir / user['web_dir']
         run_webui_tests(web_dir)
 
-def test_with_current_shared(repo_names: t.List[str]):
+def test_local_shared(repo_names: t.List[str], args):
     """
     test the current shared code with target repos.
     """
@@ -115,33 +117,56 @@ def test_with_current_shared(repo_names: t.List[str]):
         if name not in repos:
             raise ValueError(f'unknown repo name: {name}')
         user = repos[name]
-        clone_dir = setup_user(user, name)
+        clone_dir = setup_user(user, name, repo_hash=args.repo_hash)
         web_dir = clone_dir / user['web_dir']
         overwrite_with_cur_shared(user, name)
         run_webui_tests(web_dir)
 
 
-if __name__ == '__main__':
-    parser.add_argument('--sw-hash', help='desired shared-web githash to test')
+def get_user_inputs():
+    """
+    parse and validate user inputs
+    """
+    parser.add_argument('--sw-hash', help='desired shared-web githash to test with')
     parser.add_argument('--test-local',
                         help='test the repositories with the current shared code',
                         action='store_true', default=False)
     parser.add_argument('--repos',
                         help=f'repos to test. available: {", ".join(repos.keys())}',
                         nargs='+')
+    parser.add_argument('--repo-hash', type=str,
+                        help='git hash of the repo to test. defaults to master')
     args = parser.parse_args()
     repos_to_test = args.repos or repos.keys()
+
     # we cannot deduce the current shared-web git hash when using subtree
-    for repo in repos_to_test:
-        if not repos[repo]['using_sm'] and args.sw_hash is None:
-            raise argparse.ArgumentError(None, '--sw-hash is required for subtree setup')
+    if not args.test_local:
+        for repo in repos_to_test:
+            if not repos[repo]['using_sm'] and args.sw_hash is None:
+                raise argparse.ArgumentError(None, '--sw-hash is required for subtree setup')
+
+    if args.repo_hash and len(repos_to_test) > 1:
+        # implementation limitation
+        raise argparse.ArgumentError(None, '--repo-hash can only be used with one repo')
+
     # get current git hash from cli args as first argument through sys.args if one is provided
-    sm_hash = args.sw_hash if args.sw_hash else get_current_hash()
+    sw_hash = args.sw_hash if args.sw_hash else get_current_hash()
 
     if args.test_local:
-        if pathlib.Path.cwd().name != 'shared':
+        if args.sw_hash:
+            raise argparse.ArgumentError(None,
+                                     '--sw-hash cannot be used with --test-local')
+        dir_name = pathlib.Path.cwd().name
+        if dir_name != 'shared' and dir_name != 'shared-web':
             raise argparse.ArgumentError(None,
                                          '--test-local must be run from the shared directory root')
-        test_with_current_shared(repos_to_test)
+
+    return args, repos_to_test, sw_hash
+
+if __name__ == '__main__':
+    args, repos_to_test, sw_hash = get_user_inputs()
+
+    if args.test_local:
+        test_local_shared(repos_to_test, args)
     else:
-        test(sm_hash, repos_to_test)
+        test(sw_hash, repos_to_test, args)

--- a/bin/test.py
+++ b/bin/test.py
@@ -129,7 +129,8 @@ def get_user_inputs():
     """
     parser.add_argument('--sw-hash', help='desired shared-web githash to test with')
     parser.add_argument('--test-local',
-                        help='test the repositories with the current shared code',
+                        help='test the repositories with the current shared code' +
+                        'This must be run from the shared-web root',
                         action='store_true', default=False)
     parser.add_argument('--repos',
                         help=f'repos to test. available: {", ".join(repos.keys())}',
@@ -156,10 +157,6 @@ def get_user_inputs():
         if args.sw_hash:
             raise argparse.ArgumentError(None,
                                      '--sw-hash cannot be used with --test-local')
-        dir_name = pathlib.Path.cwd().name
-        if dir_name != 'shared' and dir_name != 'shared-web':
-            raise argparse.ArgumentError(None,
-                                         '--test-local must be run from the shared directory root')
 
     return args, repos_to_test, sw_hash
 


### PR DESCRIPTION
git subtree pull fails for reasons I don't understand: https://github.com/determined-ai/shared-web/runs/7258838062

the local testing strategy is more resilient to changes on how shared-code is pulled down

- [ ] once we're happy with tests close this and add the changes through core