### PR TITLE
fix: overflow of long names without spaces [WEB-485]

### DIFF
--- a/styles/antd.scss
+++ b/styles/antd.scss
@@ -4,6 +4,7 @@ html {
   .ant-breadcrumb {
     align-items: center;
     display: flex;
+    word-break: break-word;
 
     li:last-child {
       /* stylelint-disable no-descending-specificity */


### PR DESCRIPTION
in breadcrumbs, use this css change to break up experiment names or other long strings without natural word breaks such as spaces
